### PR TITLE
Support for Spriter Beta 3's file-level pivot_x and pivot_y definitions

### DIFF
--- a/lib/src/treefortress/spriter/AnimationSet.as
+++ b/lib/src/treefortress/spriter/AnimationSet.as
@@ -43,7 +43,9 @@ package treefortress.spriter
 					}
 					piece.width = file.@width * _scale;
 					piece.height = file.@height * _scale;
-					piecesByFolderId[piece.folderId] = piece;					
+					piece.pivotX = (file.@pivot_x == undefined)? 0 : file.@pivot_x;
+					piece.pivotY = (file.@pivot_y == undefined)? 1 : file.@pivot_y;
+					piecesByFolderId[piece.folderId] = piece;
 				}
 			}
 			
@@ -99,8 +101,8 @@ package treefortress.spriter
 						//Ignore bones
 						if(!isBone){
 							child.piece = piecesByFolderId[childData.@folder + "_" + childData.@file];
-							child.pivotX = (childData.@pivot_x == undefined)? 0 : childData.@pivot_x;
-							child.pivotY = (childData.@pivot_y == undefined)? 1 : childData.@pivot_y;
+							child.pivotX = (childData.@pivot_x == undefined)? child.piece.pivotX : childData.@pivot_x;
+							child.pivotY = (childData.@pivot_y == undefined)? child.piece.pivotY : childData.@pivot_y;
 							child.pixelPivotX = child.piece.width * child.pivotX;
 							child.pixelPivotY = child.piece.height * (1 - child.pivotY);
 						}

--- a/lib/src/treefortress/spriter/core/Piece.as
+++ b/lib/src/treefortress/spriter/core/Piece.as
@@ -7,6 +7,8 @@ package treefortress.spriter.core
 		public var name:String;
 		public var width:int;
 		public var height:int;
+		public var pivotX:Number;
+		public var pivotY:Number;
 		
 		public function Piece() {
 		}
@@ -14,7 +16,5 @@ package treefortress.spriter.core
 		public function get folderId():String {
 			return folder + "_" + id;
 		}
-		
-		
 	}
 }


### PR DESCRIPTION
I was struggling with this today while playing around with Spriter Beta 3, and figured it might be useful to merge in. :)

Not sure if this is all of the changes to SCML in Beta 3, but it does seem to fix the only problem I've run into thusfar.
